### PR TITLE
Rewrite PlayerCard and convert back to XCode 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 xcode_project: Pandemic.xcodeproj
 xcode_schema: Pandemic
-osx_image: xcode7.3
+osx_image: xcode7
 script:
 - xcodebuild clean build test -project Pandemic.xcodeproj -scheme Pandemic
 

--- a/Pandemic/City.swift
+++ b/Pandemic/City.swift
@@ -104,7 +104,7 @@ public struct City : Equatable, Hashable {
      ````
     */
     public static func findByName(portionOfName:String) -> [City] {
-        return allCards.findByName(portionOfName)
+        return allCards.findCityByName(portionOfName)
     }
 
 }

--- a/Pandemic/Errors.swift
+++ b/Pandemic/Errors.swift
@@ -18,3 +18,7 @@ public enum GameError : ErrorType {
     case DriveOrFerryCityUnreachable(to:String, from:String)
 }
 
+public enum ArgumentError : ErrorType {
+    case OutOfRange(String)
+}
+

--- a/Pandemic/GameBoard.swift
+++ b/Pandemic/GameBoard.swift
@@ -194,7 +194,7 @@ public class GameBoard {
 
 
     public func findCityByName(name:String) -> [GameBoardCity] {
-        return allCities.findByName(name)
+        return allCities.findCityByName(name)
     }
 }
 

--- a/Pandemic/Graph/Graph.swift
+++ b/Pandemic/Graph/Graph.swift
@@ -266,7 +266,7 @@ public class Graph<V: Equatable>: CustomStringConvertible, SequenceType, Collect
     
     public func generate() -> Generator {
         var index = 0
-        return AnyGenerator {
+        return anyGenerator {
             if index < self.vertices.count {
                 index += 1
                 return self.vertexAtIndex(index - 1)

--- a/Pandemic/Player.swift
+++ b/Pandemic/Player.swift
@@ -13,7 +13,7 @@ public class Player {
 
     let handLimit:Int
     public let character:Character
-    private(set) public var cards:Set<PlayerCard> = []
+    private(set) public var cards:[PlayerCard] = []
 
     public var characterName:String {
         return character.name
@@ -30,6 +30,6 @@ public class Player {
     }
 
     func dealCard(card:PlayerCard) {
-        cards.insert(card)
+        cards.append(card)
     }
 }

--- a/PandemicTests/PlayerCardTests.swift
+++ b/PandemicTests/PlayerCardTests.swift
@@ -11,74 +11,37 @@ import XCTest
 
 class PlayerCardTests: XCTestCase {
 
-    func testCanFindSanFrancisco() {
-        let actualCity = PlayerCard.findByName("san ").first!
+    let cards = [CityCard.santiago, CityCard.sãopaulo, CityCard.bogotá, CityCard.sanfrancisco, CityCard.atlanta]
 
-        XCTAssertEqual(PlayerCard.sanfrancisco, actualCity)
+    func testCanFindSanFrancisco() {
+        let actualCity = cards.findCityByName("san ").first!
+
+        XCTAssertEqual(CityCard.sanfrancisco, actualCity)
     }
 
     func testCanFindByAnyMatchingSubstring() {
-        let actualCity = PlayerCard.findByName("anti").first!
+        let actualCity = cards.findCityByName("anti").first!
 
-        XCTAssertEqual(PlayerCard.santiago, actualCity)
+        XCTAssertEqual(CityCard.santiago, actualCity)
     }
 
     func testCanFindSáoPaulo() {
-        let actualCity = PlayerCard.findByName("sao").first!
+        let actualCity = cards.findCityByName("sao").first!
 
-        XCTAssertEqual(PlayerCard.sãopaulo, actualCity)
+        XCTAssertEqual(CityCard.sãopaulo, actualCity)
 
 
-        let actualCity2 = PlayerCard.findByName("são").first!
-        XCTAssertEqual(PlayerCard.sãopaulo, actualCity2)
+        let actualCity2 = cards.findCityByName("são").first!
+        XCTAssertEqual(CityCard.sãopaulo, actualCity2)
     }
 
     func testCanFindBogotá() {
-        var actualCity = PlayerCard.findByName("bogota").first!
-        XCTAssertEqual(PlayerCard.bogotá, actualCity)
+        var actualCity = cards.findCityByName("bogota").first!
+        XCTAssertEqual(CityCard.bogotá, actualCity)
 
-        actualCity = PlayerCard.findByName("gotá").first!
-        XCTAssertEqual(PlayerCard.bogotá, actualCity)
+        actualCity = cards.findCityByName("gotá").first!
+        XCTAssertEqual(CityCard.bogotá, actualCity)
     }
 
 }
 
-class InfectionCardTests: XCTestCase {
-
-    func testCanFindSanFrancisco() {
-        let actualCity = InfectionCard.findByName("san ").first!
-
-        XCTAssertEqual(InfectionCard.sanfrancisco, actualCity)
-    }
-
-    func testCanFindByAnyMatchingSubstring() {
-        let actualCity = InfectionCard.findByName("anti").first!
-
-        XCTAssertEqual(InfectionCard.santiago, actualCity)
-    }
-
-    func testCanFindSáoPaulo() {
-        let actualCity = InfectionCard.findByName("sao").first!
-
-        XCTAssertEqual(InfectionCard.sãopaulo, actualCity)
-
-
-        let actualCity2 = InfectionCard.findByName("são").first!
-        XCTAssertEqual(InfectionCard.sãopaulo, actualCity2)
-    }
-
-    func testCanFindBogotá() {
-        var actualCity = InfectionCard.findByName("bogota").first!
-        XCTAssertEqual(InfectionCard.bogotá, actualCity)
-
-        actualCity = InfectionCard.findByName("gotá").first!
-        XCTAssertEqual(InfectionCard.bogotá, actualCity)
-    }
-
-    func testPerformance() {
-        self.measureBlock {
-            PlayerCardDeck.shuffledDeck()
-        }
-    }
-    
-}

--- a/PandemicTests/PlayerTests.swift
+++ b/PandemicTests/PlayerTests.swift
@@ -19,9 +19,9 @@ class PlayerTests: XCTestCase {
     func testDealPlayerACard_ThenItHasThatCard() {
 
         let player = Player(playingCharacter: Pandemic.Character(withName: "mark", andProfession: .Scientist))
-        player.dealCard(PlayerCard.santiago)
+        player.dealCard(PlayerCard.City(CityCard.santiago))
 
-        XCTAssertTrue(player.cards.contains(PlayerCard.santiago))
+        XCTAssertTrue(player.cards.contains(PlayerCard.City(CityCard.santiago)))
 
     }
 

--- a/PlayWithPandemic.playground/Contents.swift
+++ b/PlayWithPandemic.playground/Contents.swift
@@ -3,45 +3,10 @@
 import Cocoa
 import Pandemic
 
-PlayerCardDeck.shuffledDeck().cards.forEach {
-    print($0)
-}
+PlayerCard.Epidemic
+PlayerCard.City(CityCard.santiago)
+PlayerCard.City(CityCard.sãopaulo)
+PlayerCard.Event(EventCard.LocalInitiative)
 
 
 
-PlayerCardDeck.shuffledDeck().cards.count
-
-
-//
-//let builder = GameEngineBuilder()
-//try! builder.addPlayerWithName("tim", andProfession: .Medic)
-//try! builder.addPlayerWithName("mark", andProfession: .Scientist)
-//
-//let engine = builder.createGame()
-//print (engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("Miami")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("Bog")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("paulo")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("lagos")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("chicago")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("san ")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("tokyo")
-//print(engine.debugDescription)
-//
-//try! engine.driveOrFerryToCity("osaka")
-//print(engine.debugDescription)
-//
-//


### PR DESCRIPTION
- Hard to test in XCode 7.3 with playgrounds. They fail to launch.
  Change the travis file back to latest released version.
- Rewrite PlayerCard to be an enum of Epidemic, Event cards and
  City cards.
